### PR TITLE
Handle configuration changes properly

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         android:theme="@style/PumpkinTheme">
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -20,19 +19,15 @@
         </activity>
         <activity
             android:name=".NewsDetailActivity"
-            android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_news_detail" />
         <activity
             android:name=".AboutActivity"
-            android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_about" />
         <activity
             android:name=".SettingsActivity"
-            android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_settings" />
         <activity
             android:name=".NewsCommentsActivity"
-            android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_news_comments" />
     </application>
 

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailActivity.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailActivity.java
@@ -18,12 +18,10 @@ import io.pumpkinz.pumpkinreader.model.News;
 
 public class NewsDetailActivity extends PumpkinReaderActivity {
 
-    public static final int TAB_LINK_IDX = 0;
-    public static final int TAB_COMMENTS_IDX = 1;
-
     private News news;
-    private WebView webView;
+    private ViewPager viewPager;
     private TabLayout tabLayout;
+    private WebView webView;
     private NewsDetailViewPagerAdapter pagerAdapter;
 
     @Override
@@ -34,7 +32,7 @@ public class NewsDetailActivity extends PumpkinReaderActivity {
 
         news = Parcels.unwrap(getIntent().getParcelableExtra(Constants.NEWS));
 
-        ViewPager viewPager = (ViewPager) findViewById(R.id.news_detail_pager);
+        viewPager = (ViewPager) findViewById(R.id.news_detail_pager);
         setUpViewPager(viewPager);
 
         tabLayout = (TabLayout) findViewById(R.id.news_detail_tab);
@@ -59,7 +57,7 @@ public class NewsDetailActivity extends PumpkinReaderActivity {
 
     @Override
     public void onBackPressed() {
-        if (tabLayout.getSelectedTabPosition() != TAB_LINK_IDX) {
+        if (tabLayout.getSelectedTabPosition() != NewsDetailViewPagerAdapter.TAB_LINK_IDX) {
             super.onBackPressed();
             return;
         }
@@ -72,11 +70,7 @@ public class NewsDetailActivity extends PumpkinReaderActivity {
     }
 
     private void setUpViewPager(ViewPager viewPager) {
-        pagerAdapter = new NewsDetailViewPagerAdapter(getSupportFragmentManager());
-
-        pagerAdapter.addFragment(getResources().getString(R.string.link), new WebViewFragment());
-        pagerAdapter.addFragment(getResources().getString(R.string.comments), new NewsDetailFragment());
-
+        pagerAdapter = new NewsDetailViewPagerAdapter(getSupportFragmentManager(), getResources());
         viewPager.setAdapter(pagerAdapter);
     }
 
@@ -84,7 +78,7 @@ public class NewsDetailActivity extends PumpkinReaderActivity {
         tabLayout.setupWithViewPager(viewPager);
 
         if (news.getUrl() == null || news.getUrl().isEmpty()) {
-            tabLayout.getTabAt(TAB_COMMENTS_IDX).select();
+            tabLayout.getTabAt(NewsDetailViewPagerAdapter.TAB_COMMENTS_IDX).select();
         }
     }
 
@@ -113,7 +107,8 @@ public class NewsDetailActivity extends PumpkinReaderActivity {
 
     private WebView getWebView() {
         if (webView == null) {
-            webView = (WebView) pagerAdapter.getItem(TAB_LINK_IDX).getView().findViewById(R.id.news_web_view);
+            WebViewFragment webViewFragment = (WebViewFragment) pagerAdapter.instantiateItem(viewPager, viewPager.getCurrentItem());
+            webView = (WebView) webViewFragment.getView().findViewById(R.id.news_web_view);
         }
 
         return webView;

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailFragment.java
@@ -33,6 +33,9 @@ import rx.subscriptions.Subscriptions;
 
 public class NewsDetailFragment extends Fragment {
 
+    private static final String SAVED_DATASET = "io.pumpkinz.pumpkinreader.model.saved_dataset";
+    private static final String SAVED_COMMENTS = "io.pumpkinz.pumpkinreader.model.saved_comments";
+
     private Subscription subscription = Subscriptions.empty();
     private DataSource dataSource;
     private NewsDetailAdapter newsDetailAdapter;
@@ -70,7 +73,20 @@ public class NewsDetailFragment extends Fragment {
         newsDetailAdapter = new NewsDetailAdapter(this, news);
         newsDetail.setAdapter(newsDetailAdapter);
 
-        loadComments(news);
+        if (savedInstanceState != null) {
+            List<Comment> savedDataset = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_DATASET));
+            List<Comment> savedComments = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_COMMENTS));
+            newsDetailAdapter.addComment(savedDataset, savedComments);
+        } else {
+            loadComments(news);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable(SAVED_DATASET, Parcels.wrap(newsDetailAdapter.getDataSet()));
+        outState.putParcelable(SAVED_COMMENTS, Parcels.wrap(newsDetailAdapter.getComments()));
     }
 
     private void loadComments(News news) {

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -38,6 +38,7 @@ public class NewsListFragment extends Fragment {
 
     private static final int N_NEWS_PER_LOAD = 50;
     private static final int LOADING_THRESHOLD = 15;
+    private static final String SAVED_NEWS = "io.pumpkinz.pumpkinreader.model.saved_news";
 
     private RecyclerView newsList;
     private NewsAdapter newsAdapter;
@@ -58,7 +59,7 @@ public class NewsListFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, final Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_news_list, container, false);
 
         swipeRefreshLayout = (SwipeRefreshLayout) view.findViewById(R.id.news_list_refresh_container);
@@ -75,7 +76,7 @@ public class NewsListFragment extends Fragment {
         swipeRefreshLayout.post(new Runnable() {
             @Override
             public void run() {
-                swipeRefreshLayout.setRefreshing(true);
+                swipeRefreshLayout.setRefreshing(savedInstanceState == null);
             }
         });
 
@@ -93,7 +94,19 @@ public class NewsListFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         setUpNewsList(view);
-        loadNews(0, N_NEWS_PER_LOAD, true);
+
+        if (savedInstanceState != null) {
+            List<News> savedNews = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_NEWS));
+            newsAdapter.addDataset(savedNews);
+        } else {
+            loadNews(0, N_NEWS_PER_LOAD, true);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable(SAVED_NEWS, Parcels.wrap(newsAdapter.getDataSet()));
     }
 
     public void forceUnsubscribe() {

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -103,7 +103,7 @@ public class NewsListFragment extends Fragment {
 
         if (newsAdapter.getDataSet().isEmpty()) { //Config changes in the middle of refreshing News
             subscription = stories.subscribe(new StoriesSubscriber(true));
-        } else if (hasLoadingMore(newsAdapter)) { //Config changes in the middle of loading more News
+        } else if (newsAdapter.hasLoadingMore()) { //Config changes in the middle of loading more News
             subscription = stories.subscribe(new StoriesSubscriber(false));
         }
     }
@@ -226,20 +226,6 @@ public class NewsListFragment extends Fragment {
         });
     }
 
-    private void removeLoadingMoreItem() {
-        NewsAdapter adapter = (NewsAdapter) newsList.getAdapter();
-        int lastItemIdx = adapter.getItemCount() - 1;
-
-        if (hasLoadingMore(adapter)) {
-            adapter.removeItem(lastItemIdx);
-        }
-    }
-
-    private boolean hasLoadingMore(NewsAdapter adapter) {
-        int lastItemIdx = adapter.getItemCount() - 1;
-        return (lastItemIdx >= 0 && adapter.getItem(lastItemIdx) == null);
-    }
-
     private class StoriesSubscriber extends Subscriber<List<News>> {
 
         public StoriesSubscriber(boolean isRefresh) {
@@ -268,7 +254,7 @@ public class NewsListFragment extends Fragment {
             Log.d("stories", e.toString());
 
             setRefreshingState(false);
-            removeLoadingMoreItem();
+            newsAdapter.removeLoadingMoreItem();
 
             Toast toast = Toast.makeText(getActivity(), R.string.unknown, Toast.LENGTH_LONG);
             if (e.getClass() == TimeoutException.class) {
@@ -284,7 +270,7 @@ public class NewsListFragment extends Fragment {
         @Override
         public void onNext(List<News> items) {
             Log.d("stories", String.valueOf(items.size()));
-            removeLoadingMoreItem();
+            newsAdapter.removeLoadingMoreItem();
             newsAdapter.addDataset(items);
         }
 

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -66,7 +66,7 @@ public class NewsListFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, final Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_news_list, container, false);
 
         swipeRefreshLayout = (SwipeRefreshLayout) view.findViewById(R.id.news_list_refresh_container);

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/WebViewFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/WebViewFragment.java
@@ -3,6 +3,7 @@ package io.pumpkinz.pumpkinreader;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,6 +20,8 @@ import io.pumpkinz.pumpkinreader.model.News;
 
 public class WebViewFragment extends Fragment {
 
+    private WebView webView;
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -30,7 +33,7 @@ public class WebViewFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         News news = Parcels.unwrap(getActivity().getIntent().getParcelableExtra(Constants.NEWS));
-        final WebView webView = (WebView) view.findViewById(R.id.news_web_view);
+        webView = (WebView) view.findViewById(R.id.news_web_view);
 
         final ProgressBar progressBar = (ProgressBar) view.findViewById(R.id.web_view_progress);
         progressBar.setVisibility(View.VISIBLE);
@@ -70,7 +73,16 @@ public class WebViewFragment extends Fragment {
 
         webView.setBackgroundColor(0);
 
-        webView.loadUrl(news.getUrl());
+        if (savedInstanceState == null) {
+            webView.loadUrl(news.getUrl());
+        } else {
+            webView.restoreState(savedInstanceState);
+        }
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        webView.saveState(outState);
+    }
 }

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/WebViewFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/WebViewFragment.java
@@ -85,4 +85,5 @@ public class WebViewFragment extends Fragment {
         super.onSaveInstanceState(outState);
         webView.saveState(outState);
     }
+
 }

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsAdapter.java
@@ -118,6 +118,19 @@ public class NewsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         return this.dataset.size();
     }
 
+    public void removeLoadingMoreItem() {
+        int lastItemIdx = getItemCount() - 1;
+
+        if (hasLoadingMore()) {
+            removeItem(lastItemIdx);
+        }
+    }
+
+    public boolean hasLoadingMore() {
+        int lastItemIdx = getItemCount() - 1;
+        return (lastItemIdx >= 0 && getItem(lastItemIdx) == null);
+    }
+
     public List<News> getDataSet() {
         return this.dataset;
     }

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsAdapter.java
@@ -118,6 +118,10 @@ public class NewsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         return this.dataset.size();
     }
 
+    public List<News> getDataSet() {
+        return this.dataset;
+    }
+
     public void addDataset(List<News> dataset) {
         this.dataset.addAll(dataset);
         notifyDataSetChanged();

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
@@ -189,6 +189,19 @@ public class NewsDetailAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return dataset.size() + 1;
     }
 
+    public void removeLoadingItem() {
+        int lastItemIdx = getCommentCount() - 1;
+
+        if (hasLoadingMore()) {
+            removeItem(lastItemIdx);
+        }
+    }
+
+    public boolean hasLoadingMore() {
+        int lastItemIdx = getCommentCount() - 1;
+        return (lastItemIdx >= 0 && getDataSetItem(lastItemIdx) == null);
+    }
+
     public int getCommentCount() {
         return dataset.size();
     }
@@ -199,6 +212,10 @@ public class NewsDetailAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public List<Comment> getComments() {
         return this.comments;
+    }
+
+    public Comment getDataSetItem(int position) {
+        return this.dataset.get(position);
     }
 
     public void addComment(List<Comment> dataset) {

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
@@ -193,6 +193,14 @@ public class NewsDetailAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return dataset.size();
     }
 
+    public List<Comment> getDataSet() {
+        return this.dataset;
+    }
+
+    public List<Comment> getComments() {
+        return this.comments;
+    }
+
     public void addComment(List<Comment> dataset) {
         this.comments.addAll(dataset);
         this.dataset.addAll(dataset);

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailViewPagerAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailViewPagerAdapter.java
@@ -1,43 +1,55 @@
 package io.pumpkinz.pumpkinreader.data;
 
+import android.content.res.Resources;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.pumpkinz.pumpkinreader.NewsDetailFragment;
+import io.pumpkinz.pumpkinreader.R;
+import io.pumpkinz.pumpkinreader.WebViewFragment;
 
 
 public class NewsDetailViewPagerAdapter extends FragmentPagerAdapter {
 
-    private List<String> titles;
-    private List<Fragment> fragments;
+    private static final int NUM_FRAGMENTS = 2;
+    public static final int TAB_LINK_IDX = 0;
+    public static final int TAB_COMMENTS_IDX = 1;
 
-    public NewsDetailViewPagerAdapter(FragmentManager fm) {
+    private Resources res;
+
+    public NewsDetailViewPagerAdapter(FragmentManager fm, Resources res) {
         super(fm);
-
-        this.titles = new ArrayList<>();
-        this.fragments = new ArrayList<>();
+        this.res = res;
     }
 
     @Override
     public Fragment getItem(int position) {
-        return this.fragments.get(position);
+        switch (position) {
+            case TAB_LINK_IDX:
+                return new WebViewFragment();
+            case TAB_COMMENTS_IDX:
+                return new NewsDetailFragment();
+            default:
+                throw new IndexOutOfBoundsException();
+        }
     }
 
     @Override
     public int getCount() {
-        return this.fragments.size();
+        return NUM_FRAGMENTS;
     }
 
     @Override
-    public CharSequence getPageTitle(int postition) {
-        return this.titles.get(postition);
-    }
-
-    public void addFragment(String title, Fragment fragment) {
-        this.titles.add(title);
-        this.fragments.add(fragment);
+    public CharSequence getPageTitle(int position) {
+        switch (position) {
+            case TAB_LINK_IDX:
+                return res.getString(R.string.link);
+            case TAB_COMMENTS_IDX:
+                return res.getString(R.string.comments);
+            default:
+                throw new IndexOutOfBoundsException();
+        }
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     </plurals>
 
     <string name="timeout">Connection Timeout. Please try again.</string>
+    <string name="endoflist">You have reached the end of list.</string>
+    <string name="unknown">Unknown error occured. Please try again.</string>
 
     <!--Begin Time Ago Strings-->
     <string name="time_ago_prefix"></string>


### PR DESCRIPTION
Handled on NewsListFragment and NewsDetailFragment.

It's a bit slower than `android:configChanges="orientation|screenSize"`, but that needs to be removed for tablet support.

@wiseodd 
