### PR TITLE
Fix bug app goes back to MainActivity when user clicks home while on NewsDetailActivity

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailFragment.java
@@ -26,6 +26,7 @@ import io.pumpkinz.pumpkinreader.etc.DividerItemDecoration;
 import io.pumpkinz.pumpkinreader.model.Comment;
 import io.pumpkinz.pumpkinreader.model.News;
 import io.pumpkinz.pumpkinreader.service.DataSource;
+import io.pumpkinz.pumpkinreader.util.CommentParcel;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
@@ -87,11 +88,14 @@ public class NewsDetailFragment extends Fragment {
         }
 
         if (news != null && savedInstanceState != null) {
-            List<Comment> savedDataset = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_DATASET));
-            List<Comment> savedComments = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_COMMENTS));
-            newsDetailAdapter.addComment(savedDataset, savedComments);
+            List<CommentParcel> savedDatasetParcel = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_DATASET));
+            List<CommentParcel> savedCommentsParcel = Parcels.unwrap(savedInstanceState.getParcelable(SAVED_COMMENTS));
 
-            if (!newsDetailAdapter.hasLoadingMore()) {
+            if (savedDatasetParcel != null && savedCommentsParcel != null) {
+                List<Comment> savedDataset = CommentParcel.fromCommentParcels(savedDatasetParcel, news);
+                List<Comment> savedComments = CommentParcel.fromCommentParcels(savedCommentsParcel, news);
+                newsDetailAdapter.addComment(savedDataset, savedComments);
+
                 RecyclerView.ItemDecoration itemDecoration =
                         new DividerItemDecoration(getActivity(), DividerItemDecoration.VERTICAL_LIST);
                 newsDetail.addItemDecoration(itemDecoration);
@@ -109,9 +113,9 @@ public class NewsDetailFragment extends Fragment {
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
-        if (newsDetailAdapter != null) {
-            outState.putParcelable(SAVED_DATASET, Parcels.wrap(newsDetailAdapter.getDataSet()));
-            outState.putParcelable(SAVED_COMMENTS, Parcels.wrap(newsDetailAdapter.getComments()));
+        if (newsDetailAdapter != null && !newsDetailAdapter.hasLoadingMore()) {
+            outState.putParcelable(SAVED_DATASET, Parcels.wrap(CommentParcel.fromComments(newsDetailAdapter.getDataSet())));
+            outState.putParcelable(SAVED_COMMENTS, Parcels.wrap(CommentParcel.fromComments(newsDetailAdapter.getComments())));
         }
     }
 

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -111,6 +111,7 @@ public class NewsListFragment extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+        Log.d("Pumpkin", "NewsList save instance");
         outState.putParcelable(SAVED_NEWS, Parcels.wrap(newsAdapter.getDataSet()));
     }
 

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -111,7 +111,6 @@ public class NewsListFragment extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log.d("Pumpkin", "NewsList save instance");
         outState.putParcelable(SAVED_NEWS, Parcels.wrap(newsAdapter.getDataSet()));
     }
 

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
@@ -1,16 +1,15 @@
 package io.pumpkinz.pumpkinreader.model;
 
-import android.os.Parcelable;
-
-import org.parceler.Parcel;
+import android.util.Log;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.pumpkinz.pumpkinreader.util.CommentParcel;
 
-@Parcel
-public class Comment extends Item implements Serializable, Parcelable {
+
+public class Comment extends Item implements Serializable {
 
     int parent;
     List<Integer> kids;
@@ -39,6 +38,20 @@ public class Comment extends Item implements Serializable, Parcelable {
         this.expanded = true;
         this.hidden = false;
         this.level = 0;
+    }
+
+    public Comment(CommentParcel commentParcel) {
+        super(commentParcel.getId(), commentParcel.isDeleted(),
+                commentParcel.getType().toString(), commentParcel.getBy(),
+                commentParcel.getTime().getTime(), commentParcel.getText(),
+                commentParcel.isDead());
+        parent = commentParcel.getParentId();
+        kids = commentParcel.getCommentIds();
+        childComments = new ArrayList<>();
+        expanded = commentParcel.isExpanded();
+        hidden = commentParcel.isHidden();
+        level = commentParcel.getLevel();
+        allChildCount = commentParcel.getAllChildCount();
     }
 
     public int getParentId() {
@@ -118,21 +131,6 @@ public class Comment extends Item implements Serializable, Parcelable {
                 .append("\n");
 
         return sb.toString();
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(android.os.Parcel dest, int flags) {
-        dest.writeInt(parent);
-        dest.writeList(kids);
-        dest.writeByte((byte) (expanded ? 1 : 0));
-        dest.writeByte((byte) (hidden ? 1 : 0));
-        dest.writeInt(level);
-        dest.writeInt(allChildCount);
     }
 
 }

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
@@ -1,5 +1,7 @@
 package io.pumpkinz.pumpkinreader.model;
 
+import android.os.Parcelable;
+
 import org.parceler.Parcel;
 
 import java.io.Serializable;
@@ -8,7 +10,7 @@ import java.util.List;
 
 
 @Parcel
-public class Comment extends Item implements Serializable {
+public class Comment extends Item implements Serializable, Parcelable {
 
     int parent;
     List<Integer> kids;
@@ -116,6 +118,21 @@ public class Comment extends Item implements Serializable {
                 .append("\n");
 
         return sb.toString();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel dest, int flags) {
+        dest.writeInt(parent);
+        dest.writeList(kids);
+        dest.writeByte((byte) (expanded ? 1 : 0));
+        dest.writeByte((byte) (hidden ? 1 : 0));
+        dest.writeInt(level);
+        dest.writeInt(allChildCount);
     }
 
 }

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
@@ -1,7 +1,5 @@
 package io.pumpkinz.pumpkinreader.model;
 
-import android.util.Log;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/service/DataSource.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/service/DataSource.java
@@ -2,7 +2,6 @@ package io.pumpkinz.pumpkinreader.service;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Dictionary;

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/util/CommentParcel.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/util/CommentParcel.java
@@ -1,0 +1,131 @@
+package io.pumpkinz.pumpkinreader.util;
+
+import org.parceler.Parcel;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+
+import io.pumpkinz.pumpkinreader.model.Comment;
+import io.pumpkinz.pumpkinreader.model.Item;
+import io.pumpkinz.pumpkinreader.model.News;
+
+
+@Parcel
+public class CommentParcel extends Item {
+
+    int parent;
+    List<Integer> kids;
+    boolean expanded;
+    boolean hidden;
+    int level;
+    int allChildCount;
+
+    public CommentParcel() {
+    }
+
+    public CommentParcel(Comment comment) {
+        super(comment.getId(), comment.isDeleted(), comment.getType().toString(), comment.getBy(),
+                comment.getTime().getTime(), comment.getText(), comment.isDead());
+        parent = comment.getParentId();
+        kids = comment.getCommentIds();
+        expanded = comment.isExpanded();
+        hidden = comment.isHidden();
+        level = comment.getLevel();
+        allChildCount = comment.getAllChildCount();
+    }
+
+    public static List<CommentParcel> fromComments(List<Comment> comments) {
+        ArrayList<CommentParcel> retval = new ArrayList<>();
+        for (Comment comment : comments) {
+            retval.add(new CommentParcel(comment));
+        }
+
+        return retval;
+    }
+
+    public static List<Comment> fromCommentParcels(List<CommentParcel> commentParcels, News news) {
+        List<Comment> retval = new ArrayList<>();
+        List<Comment> comments = convertToComments(commentParcels);
+
+        Dictionary<Integer, Comment> commentDict = new Hashtable<>();
+        for (Comment comment : comments) {
+            commentDict.put(comment.getId(), comment);
+        }
+
+        for (Integer commentId : news.getCommentIds()) {
+            Comment comment = commentDict.get(commentId);
+            if (comment != null) {
+                retval.add(getCommentWithChild(0, comment, commentDict));
+            }
+        }
+
+        return flattenComments(retval);
+    }
+
+    private static List<Comment> convertToComments(List<CommentParcel> commentParcels) {
+        ArrayList<Comment> retval = new ArrayList<>();
+        for (CommentParcel commentParcel : commentParcels) {
+            retval.add(new Comment(commentParcel));
+        }
+
+        return retval;
+    }
+
+    private static Comment getCommentWithChild(int level, Comment comment, Dictionary<Integer, Comment> commentDict) {
+        if (comment.getCommentIds().size() == 0) {
+            comment.setLevel(level);
+            return comment;
+        }
+
+        for (Integer commentId : comment.getCommentIds()) {
+            Comment childComment = commentDict.get(commentId);
+            if (childComment != null) {
+                childComment.setParentComment(comment);
+                comment.addChildComment(getCommentWithChild(level + 1, childComment, commentDict));
+            }
+        }
+
+        comment.setLevel(level);
+        return comment;
+    }
+
+    private static List<Comment> flattenComments(List<Comment> comments) {
+        List<Comment> retval = new ArrayList<>();
+
+        for (Comment comment : comments) {
+            retval.add(comment);
+            if (comment.getCommentIds().size() > 0) {
+                retval.addAll(flattenComments(comment.getChildComments()));
+            }
+        }
+
+        return retval;
+    }
+
+    public int getParentId() {
+        return parent;
+    }
+
+    public List<Integer> getCommentIds() {
+        return kids;
+    }
+
+    public boolean isExpanded() {
+        return expanded;
+    }
+
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public int getAllChildCount() {
+        return allChildCount;
+    }
+
+}


### PR DESCRIPTION
Fixes #73 

This is really weird.
The troublesome line of codes is this:

```
@Override
    public void onSaveInstanceState(Bundle outState) {
        super.onSaveInstanceState(outState);

        if (newsDetailAdapter != null) {
            outState.putParcelable(SAVED_DATASET, Parcels.wrap(newsDetailAdapter.getDataSet()));
            outState.putParcelable(SAVED_COMMENTS, Parcels.wrap(newsDetailAdapter.getComments()));
        }
    }
```

on `NewsDetailFragment.java`
It returns StackOverflow error because we try to wrap model with circular reference. In this case: Comment has `childComments` and `parentComment` attributes.

When there's rotation changes or user hits home (or lock the screen), that `onSaveInstanceState` is called. The weird thing is:
- if rotation changes, the method works fine (Parceler can wrap it)
- if Home button is hit or screen is locked, the method throws StackOverflowError

My first thought for solution is to create a very special way to save the instance:
1. Declare another Comment model that contains every original Comment model attributes **except** `List<Comment> childComments` and `Comment parentComment`.
2. Save those new Comment model instead (should be working because there's no circular reference anymore).
3. When unwrapping, populate that `List<Comment> childComments` and `Comment parentComment` using recursive method.

But then, an even weirder thing happened. I tried to implement Parcelable on model Comment first:

```
@Override
    public int describeContents() {
        return 0;
    }

    @Override
    public void writeToParcel(android.os.Parcel dest, int flags) {
        Log.d("Pumpkin", "writeToParcel");
        dest.writeInt(parent);
        dest.writeList(kids);
        dest.writeByte((byte) (expanded ? 1 : 0));
        dest.writeByte((byte) (hidden ? 1 : 0));
        dest.writeInt(level);
        dest.writeInt(allChildCount);
    }
```

I still haven't handled the recursive part, then I decided to try it out first. My expectation is that **writeToParcel** method will be called on `onSaveInstanceState` method.

It turned out: the **writeToParcel** method above only got called when user hits home (or lock the screen). It doesn't get called if user changes rotation. So, only implementing Parcelable actually save the problem!

Then I tried another thing: I removed the `@Parcel` annotation on model Comment (but still implementing Parcelable). My expectation is that the `onSaveInstanceState` will still work (because we still implement Parcelable). It turned out: when user changes screen orientation: yes it still works BUT the `writeToParcel` method is NOT called!

...and what about when user hit home screen? It throws error:

```
 Unable to find generated Parcelable class for io.pumpkinz.pumpkinreader.model.Comment,
verify that your class is configured properly and that the Parcelable class
io.pumpkinz.pumpkinreader.model.Comment$$Parcelable is generated by Parceler.
```

WTF!?!?!?

Actually, based on the documentation on http://developer.android.com/guide/components/activities.html#Lifecycle. Only relying on this solution is not robust.

When user hits home or lock the screen, the activity is on Paused state (hence, the activity is not destroyed). When user comes back to app, the app just resumes, that's why **although I haven't handled that recursive part (populating childComments and parentComment)**, it will still work.

But, when on Paused state and there's another app with higher priority requires memory. The paused activity will be killed, and when user open it again, it will be recreated, this time, the state will be different because the comments don't have child or parent.

What do you say @wiseodd ?
