### PR TITLE
[UI] Closes #76: Refine link and comment behavior

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailActivity.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailActivity.java
@@ -1,7 +1,9 @@
 package io.pumpkinz.pumpkinreader;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
 import android.support.v4.view.ViewPager;
@@ -40,6 +42,13 @@ public class NewsDetailActivity extends PumpkinReaderActivity {
 
         FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.news_detail_fab);
         setUpFAB(fab);
+
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean isCommentFirst = !pref.getBoolean(Constants.CONFIG_SHOW_LINK, false);
+
+        if (isCommentFirst) {
+            viewPager.setCurrentItem(Constants.TAB_COMMENTVIEW);
+        }
     }
 
     @Override

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -138,13 +138,11 @@ public class NewsListFragment extends Fragment {
                         startActivity(new Intent(Intent.ACTION_VIEW, uri));
                     }
                 }, 300);
-            }
-        } else {
-            if (shouldOpenLink) {
-                intent = new Intent(getActivity(), NewsDetailActivity.class);
-            } else {
+            } else if (!shouldOpenLink) {
                 intent = new Intent(getActivity(), NewsCommentsActivity.class);
             }
+        } else {
+            intent = new Intent(getActivity(), NewsDetailActivity.class);
         }
 
         intent.putExtra(Constants.NEWS, Parcels.wrap(news));

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/SettingsActivityFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/SettingsActivityFragment.java
@@ -1,15 +1,10 @@
 package io.pumpkinz.pumpkinreader;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.Preference;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
-
-import io.pumpkinz.pumpkinreader.etc.Constants;
 
 
-public class SettingsActivityFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class SettingsActivityFragment extends PreferenceFragment {
 
     public SettingsActivityFragment() {
     }
@@ -18,23 +13,6 @@ public class SettingsActivityFragment extends PreferenceFragment implements Shar
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.preferences);
-
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        sp.registerOnSharedPreferenceChangeListener(this);
-
-        initializePreferences(sp);
-    }
-
-    @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
-        if (s.equals(Constants.CONFIG_SHOW_LINK)) {
-            initializePreferences(sharedPreferences);
-        }
-    }
-
-    private void initializePreferences(SharedPreferences sp) {
-        Preference p = findPreference(Constants.CONFIG_EXTERNAL_BROWSER);
-        p.setEnabled(sp.getBoolean(Constants.CONFIG_SHOW_LINK, false));
     }
 
 }

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/etc/Constants.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/etc/Constants.java
@@ -36,4 +36,7 @@ public class Constants {
 
     public static final int CONN_TIMEOUT_SEC = 120;
 
+    public static final int TAB_WEBVIEW = 0;
+    public static final int TAB_COMMENTVIEW = 1;
+
 }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,34 +2,46 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <CheckBoxPreference
-        android:defaultValue="true"
-        android:key="config_show_link"
-        android:summary="Always show link first in browser before showing comments"
-        android:title="Show Link" />
+    <PreferenceCategory
+        android:key="config_cat_appearance"
+        android:title="Appearance">
 
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="config_external_browser"
-        android:summary="Use system's default web browser to show link"
-        android:title="Use External Browser" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="config_smaller_text"
+            android:summary="Reduce news list font size"
+            android:title="Smaller Text" />
 
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="config_smaller_text"
-        android:summary="Reduce news list font size"
-        android:title="Smaller Text" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="config_dark_theme"
+            android:summary="Use white on dark theme"
+            android:title="Dark Theme" />
 
-    <CheckBoxPreference
-        android:defaultValue="true"
-        android:key="config_auto_expand_comments"
-        android:summary="Auto expand all comments in comments section"
-        android:title="Auto Expand Comments" />
+    </PreferenceCategory>
 
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="config_dark_theme"
-        android:summary="Use white on dark theme"
-        android:title="Dark Theme" />
+    <PreferenceCategory
+        android:key="config_cat_behavior"
+        android:title="Behavior">
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="config_show_link"
+            android:summary="Always show link first in browser before showing comments"
+            android:title="Show Link First" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="config_external_browser"
+            android:summary="Use system's default web browser to show link"
+            android:title="Use External Browser" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="config_auto_expand_comments"
+            android:summary="Auto expand all comments in comments section"
+            android:title="Auto Expand Comments" />
+
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Refined behavior when clicking a news from news list:
1. Show Link First and Use External Browser: Go to external browser
2. Show Link First and not Use External Browser: Go to tabbed view, link section
3. Not Show Link First and Use External Browser: Go to comment activity (the one without tab)
4. Not Show Link First and not Use External Browser: Go to tabbed view, comment section

@timotiusnc review!
