### PR TITLE
Fixes #82: webview renders differently compared to Chrome

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/WebViewFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/WebViewFragment.java
@@ -1,9 +1,9 @@
 package io.pumpkinz.pumpkinreader;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -73,6 +73,7 @@ public class WebViewFragment extends Fragment {
         webView.getSettings().setUseWideViewPort(true);
         webView.getSettings().setLoadWithOverviewMode(true);
         webView.getSettings().setJavaScriptEnabled(true);
+        webView.getSettings().setDomStorageEnabled(true);
 
         webView.setBackgroundColor(0);
 

--- a/app/src/main/res/layout/fragment_web_view.xml
+++ b/app/src/main/res/layout/fragment_web_view.xml
@@ -20,7 +20,7 @@
             <WebView
                 android:id="@+id/news_web_view"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="wrap_content" />
 
         </android.support.v4.widget.NestedScrollView>
 


### PR DESCRIPTION
Fixes #82 

The key is to use `android:layout_height="wrap_content"` instead of `android:layout_height="match_parent"` on WebView's xml.
## 

However, the right way to solve the problem should be from the web's HTML. It should have added:

```
<meta name="viewport" content="width=device-width, initial-scale=1.0">
```

[That website](http://www.damninteresting.com/faxes-from-the-far-side/) only uses:

```
<meta name="viewport" content="width=device-width">
```
## 

Other problem is, that website uses HTML5 `localStorage` feature. This caused a JavaScript error. We need to enable this by adding:

```
webView.getSettings().setDomStorageEnabled(true);
```
