### PR TITLE
Fix #89: URL links on comment sometimes got truncated

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
@@ -203,7 +203,6 @@ public class NewsDetailAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 commentViewHolder.getDate().setText(this.dateFormatter.timeAgo(comment.getTime()));
                 commentViewHolder.getBody().setText(Util.trim(Html.fromHtml(comment.getText())));
                 commentViewHolder.getBody().setMovementMethod(LinkMovementMethod.getInstance());
-                commentViewHolder.getBody().setAutoLinkMask(Linkify.WEB_URLS);
 
                 if (comment.getCommentIds().size() > 0 && !comment.isExpanded()) {
                     commentViewHolder.getChildCount().setText("+" + comment.getAllChildCount() + " comments");


### PR DESCRIPTION
Fixes #89

The bug happens if we scroll the comment up and down OR we expand and unexpand it a couple times. Probably have something to do with `RecyclerView`'s `onBindViewHolder` method.

I don't really understand why this fix works, but it does its job and does not compromise other feature.

@wiseodd please double check.
