### PR TITLE
Fix #91: wrong comment date after rotation

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsCommentsActivity.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsCommentsActivity.java
@@ -11,7 +11,6 @@ import org.parceler.Parcels;
 import io.pumpkinz.pumpkinreader.etc.Constants;
 import io.pumpkinz.pumpkinreader.model.News;
 import io.pumpkinz.pumpkinreader.util.ActionUtil;
-import io.pumpkinz.pumpkinreader.util.PreferencesUtil;
 
 
 public class NewsCommentsActivity extends PumpkinReaderActivity {

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/model/Comment.java
@@ -41,7 +41,7 @@ public class Comment extends Item implements Serializable {
     public Comment(CommentParcel commentParcel) {
         super(commentParcel.getId(), commentParcel.isDeleted(),
                 commentParcel.getType().toString(), commentParcel.getBy(),
-                commentParcel.getTime().getTime(), commentParcel.getText(),
+                commentParcel.getTimeInSeconds(), commentParcel.getText(),
                 commentParcel.isDead());
         parent = commentParcel.getParentId();
         kids = commentParcel.getCommentIds();

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/model/Item.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/model/Item.java
@@ -1,5 +1,7 @@
 package io.pumpkinz.pumpkinreader.model;
 
+import android.util.Log;
+
 import java.util.Date;
 
 
@@ -22,7 +24,7 @@ public abstract class Item {
         this.deleted = deleted;
         this.type = type;
         this.by = by;
-        this.time = time * 1000;
+        this.time = time;
         this.text = text;
         this.dead = dead;
     }
@@ -45,6 +47,10 @@ public abstract class Item {
 
     public Date getTime() {
         return new Date(time * 1000);
+    }
+
+    public long getTimeInSeconds() {
+        return time;
     }
 
     public String getText() {

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/model/Item.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/model/Item.java
@@ -1,7 +1,5 @@
 package io.pumpkinz.pumpkinreader.model;
 
-import android.util.Log;
-
 import java.util.Date;
 
 

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/util/CommentParcel.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/util/CommentParcel.java
@@ -27,7 +27,7 @@ public class CommentParcel extends Item {
 
     public CommentParcel(Comment comment) {
         super(comment.getId(), comment.isDeleted(), comment.getType().toString(), comment.getBy(),
-                comment.getTime().getTime(), comment.getText(), comment.isDead());
+                comment.getTimeInSeconds(), comment.getText(), comment.isDead());
         parent = comment.getParentId();
         kids = comment.getCommentIds();
         expanded = comment.isExpanded();


### PR DESCRIPTION
Fixes #91.

It's seconds/milliseconds error.

From HN API: seconds.
Java Date object needs: milliseconds.

When rotation change: we call onSaveStateChange and save the comments into Parcelable objects, then we reconstruct it using `Item#getTime().getTime()` which returns milliseconds. Then we multiply it again with 1000 on `Item`'s constructor, then again with 1000 on `Item`'s `getTime()`.
