### PR TITLE
[UI] Fix #110: Highlighted item in sidenav not prominent enough when using dark theme

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,7 @@
         <item name="dim_title_color">@color/grey_500</item>
         <item name="list_bg_color">@color/background_dark</item>
         <item name="card_style">@style/CardView.Dark</item>
+        <item name="colorControlHighlight">@color/grey_600</item>
     </style>
 
     <style name="Divider">


### PR DESCRIPTION
Add more contrast on the sidenav selection highlight

@timotiusnc please review
