### PR TITLE
[UI] Closes #57: Improve comments expand & collapse animation

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsDetailFragment.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -94,10 +95,11 @@ public class NewsDetailFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         newsDetail = (RecyclerView) view.findViewById(R.id.news_detail);
-        newsDetail.getItemAnimator().setRemoveDuration(100);
+        newsDetail.setItemAnimator(new DefaultItemAnimator());
+        newsDetail.getItemAnimator().setRemoveDuration(200);
         newsDetail.getItemAnimator().setChangeDuration(0);
-        newsDetail.getItemAnimator().setMoveDuration(100);
-        newsDetail.getItemAnimator().setAddDuration(100);
+        newsDetail.getItemAnimator().setMoveDuration(200);
+        newsDetail.getItemAnimator().setAddDuration(200);
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
         layoutManager.setOrientation(LinearLayoutManager.VERTICAL);

--- a/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/NewsListFragment.java
@@ -1,6 +1,5 @@
 package io.pumpkinz.pumpkinreader;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -44,7 +43,6 @@ public class NewsListFragment extends Fragment {
     private static final int LOADING_THRESHOLD = 15;
     private static final String SAVED_NEWS = "io.pumpkinz.pumpkinreader.model.saved_news";
 
-    private RecyclerView newsList;
     private SwipeRefreshLayout swipeRefreshLayout;
     private NewsAdapter newsAdapter;
     private DataSource dataSource;
@@ -211,7 +209,7 @@ public class NewsListFragment extends Fragment {
     }
 
     private void setUpNewsList(View view) {
-        newsList = (RecyclerView) view.findViewById(R.id.news_list);
+        RecyclerView newsList = (RecyclerView) view.findViewById(R.id.news_list);
 
         final LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
         layoutManager.setOrientation(LinearLayoutManager.VERTICAL);


### PR DESCRIPTION
I've tried these library, but unfortunately, they're buggy for our use case.
For example for `wasabeef`:
1. Collapse first child of a comment
2. Expand it
3. Collapse the parent
4. See the bug? If not, try scrolling the list

https://github.com/wasabeef/recyclerview-animators
https://github.com/gabrielemariotti/RecyclerViewItemAnimators

So, in the end, I use the default animator, and optimize the animation time instead.

@timotiusnc please review and give me your opinion on the new animation.
