### PR TITLE
[UI] Closes #99: Tidying up news detail view

### DIFF
--- a/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
+++ b/app/src/main/java/io/pumpkinz/pumpkinreader/data/NewsDetailAdapter.java
@@ -1,11 +1,13 @@
 package io.pumpkinz.pumpkinreader.data;
 
 import android.content.res.Resources;
+import android.graphics.Typeface;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -113,6 +115,8 @@ public class NewsDetailAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     Resources r = this.fragment.getActivity().getResources();
 
                     newsViewHolder.getTitle().setText(news.getTitle());
+                    newsViewHolder.getTitle().setTextSize(TypedValue.COMPLEX_UNIT_SP, 16);
+                    newsViewHolder.getTitle().setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
                     newsViewHolder.getSubmitter().setText(news.getBy());
                     newsViewHolder.getDate().setText(this.dateFormatter.timeAgo(news.getTime()));
                     newsViewHolder.getScore().setText(Integer.toString(news.getScore()));

--- a/app/src/main/res/layout/comment_item.xml
+++ b/app/src/main/res/layout/comment_item.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
+            android:lineSpacingMultiplier="1.15"
             android:textColor="?title_color" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/news_detail.xml
+++ b/app/src/main/res/layout/news_detail.xml
@@ -19,7 +19,8 @@
             android:id="@+id/news_body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="32dp"
             android:autoLink="web"
             android:textColor="?title_color" />
 

--- a/app/src/main/res/layout/news_detail.xml
+++ b/app/src/main/res/layout/news_detail.xml
@@ -19,9 +19,10 @@
             android:id="@+id/news_body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="32dp"
+            android:layout_marginBottom="20dp"
+            android:layout_marginTop="8dp"
             android:autoLink="web"
+            android:lineSpacingMultiplier="1.15"
             android:textColor="?title_color" />
 
         <RelativeLayout

--- a/app/src/main/res/layout/news_item.xml
+++ b/app/src/main/res/layout/news_item.xml
@@ -52,6 +52,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="4dp"
             android:layout_marginTop="4dp"
+            android:lineSpacingMultiplier="1.15"
             android:textColor="?title_color"
             android:textSize="@dimen/abc_text_size_subhead_material" />
 


### PR DESCRIPTION
Two changes:
1. Now the news title in the news detail view uses Roboto Medium 16sp
2. Added more margin in news details that have text content. Best example would be Ask HN news. Should be more readable and enjoyable to read.

@timotiusnc please review, and opinion please.

I think this will also fix #109 
